### PR TITLE
feat: added slides/images support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine3.15
+FROM node:22-alpine3.22
 
 RUN apk update
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,11 +9,12 @@ services:
       - app-network
     depends_on:
       - redis_db
-    image: "hansputera/tiktok-dl:latest"
   redis_db:
     image: "redis:alpine"
     networks:
       - app-network
+    ports:
+      - 6379:6379
 
 networks:
   app-network:

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,15 +8,5 @@
 		"useragents.js",
 		"useragents.d.ts",
 		"prettier.js"
-	],
-	"dependencies": {
-		"eslint-config-google": "0.14.0"
-	},
-	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "5.33.0",
-		"@typescript-eslint/parser": "5.33.0",
-		"eslint": "8.21.0",
-		"eslint-config-prettier": "8.5.0",
-		"prettier": "2.7.1"
-	}
+	]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,8 +14,10 @@
 		"format": "prettier . --write"
 	},
 	"devDependencies": {
-		"@typescript-eslint/parser": "5.33.0",
+		"@typescript-eslint/parser": "^8.44.0",
 		"eslint": "8.21.0",
-		"prettier": "2.7.1"
+		"eslint-config-google": "^0.14.0",
+		"eslint-config-prettier": "^10.1.8",
+		"prettier": "^3.6.2"
 	}
 }

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -51,5 +51,5 @@ export abstract class BaseProvider {
         url: string,
         params?: Record<string, string>,
     ): Promise<ExtractedInfo>;
-    abstract extract(html: string): ExtractedInfo;
+    abstract extract(html: string): ExtractedInfo | Promise<ExtractedInfo>;
 }

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -10,6 +10,7 @@ export interface ExtractedInfo {
         title?: string;
         duration?: string;
     };
+    slides?: string[];
     music?: {
         url: string;
         title?: string;

--- a/packages/core/src/musicalyDownProvider.ts
+++ b/packages/core/src/musicalyDownProvider.ts
@@ -1,6 +1,7 @@
+import got from 'got';
 import {getFetch} from '../fetch';
 import {BaseProvider, ExtractedInfo} from './base';
-import { matchLink } from './utils';
+import { extractMusicalyDownImages, matchLink } from './utils';
 
 /**
  * @class MusicalyDown
@@ -51,28 +52,78 @@ export class MusicalyDown extends BaseProvider {
             },
         });
 
-        return this.extract(response.body);
+        return this.extract(JSON.stringify({
+            html: response.body,
+            headers: {
+                Cookie: res.headers['set-cookie']?.toString(),
+                Accept: '*/*',
+                Referer: this.client.defaults.options.prefixUrl.toString(),
+                Origin: this.client.defaults.options.prefixUrl.toString(),
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+            },
+        }));
     }
 
     /**
      *
-     * @param {string} html - Raw HTML
+     * @param {string} body - Raw HTML
      * @return {ExtractedInfo}
      */
-    public extract(html: string): ExtractedInfo {
+    public async extract(body: string): Promise<ExtractedInfo> {
+        const { html, headers } = JSON.parse(body);
+
         const urls = matchLink(html);
-
         const matchedUrls = urls?.filter(url => /muscdn/gi.test(url)) ?? [];
+        const musicalyDownUrls = extractMusicalyDownImages(html);
 
-        return {
+        const isSlide = musicalyDownUrls.length > 2;
+        const nonImages = matchedUrls.filter(u => u.includes('images'));
+        const image = matchedUrls.find(u => u.includes('images'));
+
+        const info: ExtractedInfo = {
             video: {
-                urls: matchedUrls.filter(murl => !murl.includes('images')),
-                thumb: matchedUrls.find(murl => murl.includes('images')),
+                urls: !isSlide ? nonImages : [],
+                thumb: image,
             },
+            slides: isSlide ? musicalyDownUrls.slice(1) : undefined,
+            author: !isSlide ? {
+                thumb: musicalyDownUrls[0],
+            } : undefined,
+            music: !isSlide ? {
+                url: nonImages[0],
+            } : undefined,
         };
+
+        if (isSlide) {
+            const tokenRenderRegex = /data:\s*"([^"]+)"/;
+            const token = tokenRenderRegex.exec(html)?.[1];
+
+            const response = await got.post('https://render.muscdn.app/slider', {
+                form: {
+                    data: token,
+                },
+                headers,
+            }).json<{
+                success: boolean;
+                url?: string;
+            }>();
+
+            if (response.success && response.url?.length) {
+                info.video = {
+                    ...info.video,
+                    urls: [response.url],
+                };
+            }
+        }
+
+        return info;
     }
 
-    public getParams() {
+    /**
+     * Get Params
+     * @return {undefined}
+     */
+    public getParams(): undefined {
         return undefined;
     }
 }

--- a/packages/core/src/nativeProvider.ts
+++ b/packages/core/src/nativeProvider.ts
@@ -92,7 +92,11 @@ export class NativeProvider extends BaseProvider {
         }
     }
 
-    public getParams() {
+    /**
+     * Return zod object for validation
+     * @return {z.ZodObject}
+     */
+    public getParams(): z.ZodObject {
         return z.object({
             'user-agent': z.string().min(5),
         })

--- a/packages/core/src/saveFromProvider.ts
+++ b/packages/core/src/saveFromProvider.ts
@@ -74,7 +74,11 @@ export class SaveFromProvider extends BaseProvider {
         };
     }
 
-    public getParams() {
+    /**
+     * Get params
+     * @return {undefined}
+     */
+    public getParams(): undefined {
         return undefined;
     }
 }

--- a/packages/core/src/saveFromProvider.ts
+++ b/packages/core/src/saveFromProvider.ts
@@ -1,3 +1,4 @@
+import got from 'got';
 import {getFetch} from '../fetch';
 import {BaseProvider, ExtractedInfo, MaintenanceProvider} from './base';
 import {deObfuscateSaveFromScript} from './utils';
@@ -17,8 +18,8 @@ export class SaveFromProvider extends BaseProvider {
     public client = getFetch('https://worker.savefrom.net');
 
     public maintenance: MaintenanceProvider = {
-        reason: 'Need advance investigate to Reverse Engineering the response scripts.'
-    }
+        reason: 'Need further investigation.',
+    };
 
     /**
      *
@@ -26,26 +27,32 @@ export class SaveFromProvider extends BaseProvider {
      * @return {Promise<ExtractedInfo>}
      */
     public async fetch(url: string): Promise<ExtractedInfo> {
+        const responseFirst = await got.get('https://en1.savefrom.net');
         const response = await this.client.post('./savefrom.php', {
             form: {
                 sf_url: url,
                 sf_submit: '',
                 new: '2',
-                lang: 'id',
+                lang: 'en',
                 country: 'id',
-                os: 'Ubuntu',
-                browser: 'Firefox',
-                channel: 'Downloader',
+                os: 'Linux',
+                browser: 'Brave',
+                channel: 'main',
                 'sf-nomad': '1',
                 url,
                 ts: Date.now(),
+                _ts: Date.now(),
+                _tsc: 0,
             },
             headers: {
-                Origin: 'https://id.savefrom.net',
-                Referer: 'https://id.savefrom.net',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+                Origin: 'https://en1.savefrom.net',
+                Referer: 'https://en1.savefrom.net',
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+                Cookies: responseFirst.headers['set-cookie']?.toString(),
             },
         });
+
+        console.log(response.body);
 
         return this.extract(response.body);
     }

--- a/packages/core/src/saveTikProvider.ts
+++ b/packages/core/src/saveTikProvider.ts
@@ -79,6 +79,7 @@ export class SaveTikProvider extends BaseProvider {
                     title: json.postinfo.media_title,
                     duration: json.duration.toString(),
                 },
+                slides: json.items ?? undefined,
                 author: {
                     username: json.postinfo.unique_id,
                     id: json.postinfo.uid,

--- a/packages/core/src/tikDownProvider.ts
+++ b/packages/core/src/tikDownProvider.ts
@@ -32,7 +32,6 @@ export class TikDownProvider extends BaseProvider {
         });
 
         const body = response.body;
-        console.log(body);
         if (/please double/gi.test(body))
         {
             return {

--- a/packages/core/src/tikDownProvider.ts
+++ b/packages/core/src/tikDownProvider.ts
@@ -32,6 +32,7 @@ export class TikDownProvider extends BaseProvider {
         });
 
         const body = response.body;
+        console.log(body);
         if (/please double/gi.test(body))
         {
             return {

--- a/packages/core/src/ttDownloaderProvider.ts
+++ b/packages/core/src/ttDownloaderProvider.ts
@@ -53,10 +53,15 @@ export class TTDownloader extends BaseProvider {
     extract(html: string): ExtractedInfo {
         const urls = matchLink(html);
         urls?.pop(); // remove 'https://snaptik.fans'
+
+        const musicUrl = urls?.find(u => /mp3/gi.test(u));
         return {
             video: {
-                urls: (urls as string[]) ?? [],
+                urls: urls?.filter(u => u !== musicUrl) ?? [],
             },
+            music: musicUrl ? {
+                url: musicUrl,
+            } : undefined,
         };
     }
 

--- a/packages/core/src/utils/extractor.ts
+++ b/packages/core/src/utils/extractor.ts
@@ -20,6 +20,11 @@ export const runObfuscatedReplaceEvalScript = (jsCode: string): string => {
     return runObfuscatedScript(jsCode.replace('eval', 'module.exports = '));
 }
 
+export const extractMusicalyDownImages = (html: string): string[] => {
+  const regex = /<img[^>]+src="(https[^"]+)"/gi;
+  return [...html.matchAll(regex)].map(m => m[1]);
+};
+
 export const runObfuscatedScript = (jsCode: string): string => {
     const transformed = jsCode
         .trim()

--- a/packages/core/src/utils/extractor.ts
+++ b/packages/core/src/utils/extractor.ts
@@ -92,9 +92,10 @@ export const matchCustomDownload = (
 
 export const deObfuscateSaveFromScript = (scriptContent: string): string => {
     const safeScript =
-        'let result;' +
+        'let result = ' +
         scriptContent
             .replace(/\/\*js\-response\*\//gi, '');
+
     const vm = new NodeVM({
         compiler: 'javascript',
         console: 'inherit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,13 +903,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.9":
-  version: 7.0.11
-  resolution: "@types/json-schema@npm:7.0.11"
-  checksum: 10/e50864a93f4dcb9de64c0c605d836f5416341c824d7a8cde1aa15a5fc68bed44b33cdcb2e04e5098339e9121848378f2d0cc5b124dec41c89203c6f67d6f344a
-  languageName: node
-  linkType: hard
-
 "@types/json5@npm:^0.0.29":
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
@@ -944,29 +937,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.33.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:5.33.0"
-    "@typescript-eslint/type-utils": "npm:5.33.0"
-    "@typescript-eslint/utils": "npm:5.33.0"
-    debug: "npm:^4.3.4"
-    functional-red-black-tree: "npm:^1.0.1"
-    ignore: "npm:^5.2.0"
-    regexpp: "npm:^3.2.0"
-    semver: "npm:^7.3.7"
-    tsutils: "npm:^3.21.0"
-  peerDependencies:
-    "@typescript-eslint/parser": ^5.0.0
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/cb1a917d692ddb75227a999002c85499e09638a74851ba3c9a883b960f19206e8fa0cda522608dea77c3afa470d3ea0a4d566025b1dde2ac913430347dff71ae
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.41.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.41.0"
@@ -988,23 +958,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/parser@npm:5.33.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:5.33.0"
-    "@typescript-eslint/types": "npm:5.33.0"
-    "@typescript-eslint/typescript-estree": "npm:5.33.0"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/b35aa21a313230a07db8e90d56a15ebe646f375480ab308e09119c85362b07d29767d327e9d304dd7a9fc6467587241a4ca1fdec71bde3fca3cac3765492e212
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.41.0
   resolution: "@typescript-eslint/parser@npm:8.41.0"
@@ -1021,6 +974,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:^8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/parser@npm:8.44.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.44.0"
+    "@typescript-eslint/types": "npm:8.44.0"
+    "@typescript-eslint/typescript-estree": "npm:8.44.0"
+    "@typescript-eslint/visitor-keys": "npm:8.44.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10/8c7ddabf46a94877e3af9b029c5e65cc99ec2983ee14842eea7e8ebccc0e24f589cdf7d2ca63ece87284ea7a4d9d622a22452ac5c66cb6ebda1b91b438e20979
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/project-service@npm:8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/project-service@npm:8.41.0"
@@ -1034,13 +1003,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.33.0"
+"@typescript-eslint/project-service@npm:8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/project-service@npm:8.44.0"
   dependencies:
-    "@typescript-eslint/types": "npm:5.33.0"
-    "@typescript-eslint/visitor-keys": "npm:5.33.0"
-  checksum: 10/0e0b6e3215fa26302b4c847c990887cc8e0b47594819678ebf45e0f344fba0cd490f3899a2992d890846e0bae0e7df3dfb74881c19dd245603bee401c4c6f8a7
+    "@typescript-eslint/tsconfig-utils": "npm:^8.44.0"
+    "@typescript-eslint/types": "npm:^8.44.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10/400b4981e6f6bd323592df7803383c0f223256f76b4876c03c2e8fa5e9470ce90a6a39555f759a391ba87bbf79add800eadf42ba06acf0732407a225790722de
   languageName: node
   linkType: hard
 
@@ -1054,6 +1026,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.44.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.44.0"
+    "@typescript-eslint/visitor-keys": "npm:8.44.0"
+  checksum: 10/5dae4a838637df522f0f71d2df238b5fd5045a374cd036e7485d39fc1b20dd1151185463c8fc35441b12c747b795c88b429a5e229fc9449ae7b15d6e7e1b6caf
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.41.0, @typescript-eslint/tsconfig-utils@npm:^8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.41.0"
@@ -1063,19 +1045,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/type-utils@npm:5.33.0"
-  dependencies:
-    "@typescript-eslint/utils": "npm:5.33.0"
-    debug: "npm:^4.3.4"
-    tsutils: "npm:^3.21.0"
+"@typescript-eslint/tsconfig-utils@npm:8.44.0, @typescript-eslint/tsconfig-utils@npm:^8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.44.0"
   peerDependencies:
-    eslint: "*"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/09fdb062b38ca7d9b1945675bdc4c3d88fcd0801043c25b31db6905b2fac07f43fb08380b3da23f25f019e5709e9a1c80a1420218570372f957884aa42e71f33
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10/c8535d481d7cda5c846d5b74b7cde7a98b636a558b45510820840dcb9928575c4f3d26b3c021fd7e47b782c6d9a73e9a8adf29191548406ac4b02e1a1dce928f
   languageName: node
   linkType: hard
 
@@ -1095,13 +1070,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/types@npm:5.33.0"
-  checksum: 10/228f97769f5160ca073d04497f8094c5a461aac1b7fefca5daaa76aadeaff8901aa81a39c2ba7daca420db23d5be36a91ca6e1378598affc2c330a987af387a8
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.41.0, @typescript-eslint/types@npm:^8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/types@npm:8.41.0"
@@ -1109,21 +1077,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.33.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:5.33.0"
-    "@typescript-eslint/visitor-keys": "npm:5.33.0"
-    debug: "npm:^4.3.4"
-    globby: "npm:^11.1.0"
-    is-glob: "npm:^4.0.3"
-    semver: "npm:^7.3.7"
-    tsutils: "npm:^3.21.0"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/c779a7999b7125fbbb5473d0fc8cb98ce6f1b1fa183506f9b936b23a9fdb660fe37d518901052ba66a50e3feda3f9f468db1e4dcc3a6f060364317a24904eb26
+"@typescript-eslint/types@npm:8.44.0, @typescript-eslint/types@npm:^8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/types@npm:8.44.0"
+  checksum: 10/9e28c95feb0d3b9ae83117a8b3db43db4e9a5d2fcbf8fd0c6e231e0ae604fe894b6725642fe3234733e81e32bec6f03b270d8a27d4258c0ee0b44a8bd8685756
   languageName: node
   linkType: hard
 
@@ -1147,19 +1104,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/utils@npm:5.33.0"
+"@typescript-eslint/typescript-estree@npm:8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.44.0"
   dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    "@typescript-eslint/scope-manager": "npm:5.33.0"
-    "@typescript-eslint/types": "npm:5.33.0"
-    "@typescript-eslint/typescript-estree": "npm:5.33.0"
-    eslint-scope: "npm:^5.1.1"
-    eslint-utils: "npm:^3.0.0"
+    "@typescript-eslint/project-service": "npm:8.44.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.44.0"
+    "@typescript-eslint/types": "npm:8.44.0"
+    "@typescript-eslint/visitor-keys": "npm:8.44.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10/b3e898cf52f6ca85d7223624889848c1cfaf7cd1deab8adb73f802dd9dfec2e3f5804c52c35bb83ad81b8f14d8bba89378cbed7d6b6ea9a97b3403eb1a4a5b15
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10/e2e579b15c49e0ef6d2da9d06105ff2c995c785b1bb6cc0a11aa124c1bcc6435ee8897a9d9d6346951a8cc329b8af6410bc982dc5e55272b9af650b11daa536a
   languageName: node
   linkType: hard
 
@@ -1178,16 +1139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.33.0":
-  version: 5.33.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.33.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:5.33.0"
-    eslint-visitor-keys: "npm:^3.3.0"
-  checksum: 10/f1ef9542a6715aa1736cb529505b56c7895a41ca53d49da56357cebc95d1171c7c20d5ac941c650ecf7eeefd0f3bae5d8fd2a33fdf36b45187f1f956b8fed8b4
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/visitor-keys@npm:8.41.0"
@@ -1195,6 +1146,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.41.0"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10/3c764be2f0d3b212c2cb7d0cc8a7b0ed378feb58883654471fd8ee943f1e124c0b78df92fe14368ceb46016b0e3ae1c47e2630ec3599aa7b4bd54f7793747657
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.44.0":
+  version: 8.44.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.44.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.44.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10/09b008b14f46ea14bb5076632745dd527982f231830141a3c789ed0cd3d7bced7340a0ccfb40c640b765de42c267202db83072587144791df4806bd68233596c
   languageName: node
   linkType: hard
 
@@ -2135,7 +2096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-google@npm:0.14.0":
+"eslint-config-google@npm:^0.14.0":
   version: 0.14.0
   resolution: "eslint-config-google@npm:0.14.0"
   peerDependencies:
@@ -2168,14 +2129,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:8.5.0":
-  version: 8.5.0
-  resolution: "eslint-config-prettier@npm:8.5.0"
+"eslint-config-prettier@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: 10/cafd93fb39997969e9e79b3e0b3466d0b8570273d15423986597b8422b7363d4a80f009aec1d1443fa2329972dafde79031b1649590cc35069b0a68d31098e7b
+  checksum: 10/03f8e6ea1a6a9b8f9eeaf7c8c52a96499ec4b275b9ded33331a6cc738ed1d56de734097dbd0091f136f0e84bc197388bd8ec22a52a4658105883f8c8b7d8921a
   languageName: node
   linkType: hard
 
@@ -2314,16 +2275,6 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 10/ee1bd4e0ec64f29109d5a625bb703d179c82e0159c86c3f1b52fc1209d2994625a137dae303c333fb308a2e38315e44066d5204998177e31974382f9fda25d5c
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "eslint-scope@npm:5.1.1"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^4.1.1"
-  checksum: 10/c541ef384c92eb5c999b7d3443d80195fcafb3da335500946f6db76539b87d5826c8f2e1d23bf6afc3154ba8cd7c8e566f8dc00f1eea25fdf3afc8fb9c87b238
   languageName: node
   linkType: hard
 
@@ -2542,13 +2493,6 @@ __metadata:
   dependencies:
     estraverse: "npm:^5.2.0"
   checksum: 10/44ffcd89e714ea6b30143e7f119b104fc4d75e77ee913f34d59076b40ef2d21967f84e019f84e1fd0465b42cdbf725db449f232b5e47f29df29ed76194db8e16
-  languageName: node
-  linkType: hard
-
-"estraverse@npm:^4.1.1":
-  version: 4.3.0
-  resolution: "estraverse@npm:4.3.0"
-  checksum: 10/3f67ad02b6dbfaddd9ea459cf2b6ef4ecff9a6082a7af9d22e445b9abc082ad9ca47e1825557b293fcdae477f4714e561123e30bb6a5b2f184fb2bad4a9497eb
   languageName: node
   linkType: hard
 
@@ -3665,15 +3609,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10/fc1fe2ee205f7c8855fa0f34c1ab0bcf14b6229e35579ec1fd1079f31d6fc8ef8eb6fd17f2f4d99788d7e339f50e047555551ebd5e434dda503696e7c6591825
-  languageName: node
-  linkType: hard
-
 "lucide-react@npm:^0.542.0":
   version: 0.542.0
   resolution: "lucide-react@npm:0.542.0"
@@ -4158,12 +4093,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.7.1":
-  version: 2.7.1
-  resolution: "prettier@npm:2.7.1"
+"prettier@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10/9d29f81c1a470efca6851cd926a3e132a8d9c9d290c3d084c917c1c5aad5c392551406cf6012c724a136bd15911ede5eadc255d121c2761813b33a541a9c34c6
+    prettier: bin/prettier.cjs
+  checksum: 10/1213691706bcef1371d16ef72773c8111106c3533b660b1cc8ec158bd109cdf1462804125f87f981f23c4a3dba053b6efafda30ab0114cc5b4a725606bb9ff26
   languageName: node
   linkType: hard
 
@@ -4442,17 +4377,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/6f60700810ef4879eb0af1d8d0626e5a2d11ba57ca7889e041d88155cb4b45629d1efebb8c6d381ecac4f87870ecb4e1b27760019d017ed1bf74a5083f4eeeb8
   languageName: node
   linkType: hard
 
@@ -4878,13 +4802,6 @@ __metadata:
 "tiktok-dl-config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "tiktok-dl-config@workspace:packages/config"
-  dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:5.33.0"
-    "@typescript-eslint/parser": "npm:5.33.0"
-    eslint: "npm:8.21.0"
-    eslint-config-google: "npm:0.14.0"
-    eslint-config-prettier: "npm:8.5.0"
-    prettier: "npm:2.7.1"
   languageName: unknown
   linkType: soft
 
@@ -4892,10 +4809,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tiktok-dl-core@workspace:packages/core"
   dependencies:
-    "@typescript-eslint/parser": "npm:5.33.0"
+    "@typescript-eslint/parser": "npm:^8.44.0"
     eslint: "npm:8.21.0"
+    eslint-config-google: "npm:^0.14.0"
+    eslint-config-prettier: "npm:^10.1.8"
     got: "npm:^12.6.1"
-    prettier: "npm:2.7.1"
+    prettier: "npm:^3.6.2"
     vm2: "npm:^3.9.19"
     zod: "npm:^4.1.5"
   languageName: unknown
@@ -4950,13 +4869,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
@@ -4968,17 +4880,6 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
-  languageName: node
-  linkType: hard
-
-"tsutils@npm:^3.21.0":
-  version: 3.21.0
-  resolution: "tsutils@npm:3.21.0"
-  dependencies:
-    tslib: "npm:^1.8.1"
-  peerDependencies:
-    typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-  checksum: 10/ea036bec1dd024e309939ffd49fda7a351c0e87a1b8eb049570dd119d447250e2c56e0e6c00554e8205760e7417793fdebff752a46e573fbe07d4f375502a5b2
   languageName: node
   linkType: hard
 
@@ -5384,13 +5285,6 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10/159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "yallist@npm:4.0.0"
-  checksum: 10/4cb02b42b8a93b5cf50caf5d8e9beb409400a8a4d85e83bb0685c1457e9ac0b7a00819e9f5991ac25ffabb56a78e2f017c1acc010b3a1babfe6de690ba531abd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
According https://github.com/hansputera/tiktok-dl/issues/111, and since TikTok support images/slides in TikTok's video, we need to support new data field like "images" or "slides" in response data to provide image URLs to download.

Here's good providers to use:
1. Musicalydown (convert to video supported by default)\
2. SaveTik

Here's not recommended providers to use:
1. DownTik - sometimes they give us bad/dead link, so we cant download the files anymore
2. SaveFrom - now maintenance
3. Snaptik - bad/dead link
4. Tikmate - bad/dead link + forbidden access 403 when we access their contents
5. TTDownloader - no slides/images supported
6. Tikdown - no support for images/slides TikTok videos (return Video not found)
